### PR TITLE
Adding Apollo Tracing to the example.

### DIFF
--- a/reviews-dgs/src/main/java/com/example/demo/ReviewsDgs.java
+++ b/reviews-dgs/src/main/java/com/example/demo/ReviewsDgs.java
@@ -1,7 +1,11 @@
 package com.example.demo;
 
+import graphql.execution.instrumentation.tracing.TracingInstrumentation;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import graphql.execution.instrumentation.Instrumentation;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class ReviewsDgs {
@@ -9,4 +13,18 @@ public class ReviewsDgs {
     public static void main(String[] args) {
         SpringApplication.run(ReviewsDgs.class, args);
     }
+
+    /**
+     * If you wan to leverage Apollo Tracing, as supported by java-graphql, you can just create a bean of type {@link TracingInstrumentation}.
+     * In this example we added a conditional property on the bean to enable/disable the Apollo Tracing.
+     * Enabled by default, you can turn it off by setting `graphql.tracing.enabled=false` in your application properties.
+     *
+     * @see <a href="https://github.com/apollographql/apollo-tracing">Apollo Tracing</a>
+     */
+    @Bean
+    @ConditionalOnProperty( prefix = "graphql.tracing", name = "enabled", matchIfMissing = true)
+    public Instrumentation tracingInstrumentation(){
+        return new TracingInstrumentation();
+    }
+
 }

--- a/shows-dgs/src/main/kotlin/com/example/demo/DemoApplication.kt
+++ b/shows-dgs/src/main/kotlin/com/example/demo/DemoApplication.kt
@@ -16,11 +16,29 @@
 
 package com.example.demo
 
+import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.instrumentation.tracing.TracingInstrumentation
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
 
 @SpringBootApplication
-class DemoApplication
+class DemoApplication {
+
+    /**
+     * If you wan to leverage Apollo Tracing, as supported by java-graphql, you can just create a bean of type [TracingInstrumentation].
+     * In this example we added a conditional property on the bean to enable/disable the Apollo Tracing.
+     * Enabled by default, you can turn it off by setting `graphql.tracing.enabled=false` in your application properties.
+     *
+     * @see [Apollo Tracing](https://github.com/apollographql/apollo-tracing)
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "graphql.tracing", name = ["enabled"], matchIfMissing = true)
+    open fun tracingInstrumentation(): Instrumentation? {
+        return TracingInstrumentation()
+    }
+}
 
 fun main(args: Array<String>) {
 	runApplication<DemoApplication>(*args)


### PR DESCRIPTION
Adding support for Apollo Tracing via java-graphql's `TracingInstrumentation`.