### PR TITLE
Enable Dependabot and Github CI Build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/reviews-dgs"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/shows-dgs"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/apollo-gateway"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI Check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java ${{ matrix.jdk-version }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - uses: actions/cache@v2
+        id: gradle-wrapper-cache
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
+          restore-keys: ${{ runner.os }}-gradlewrapper-
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Maven cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x reviews-dgs/gradlew shows-dgs/gradlew
+
+      - name: Run checks
+        run: make all

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.13-zulu

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: help all reviews/check shows/check
+.DEFAULT_GOAL := help
+
+SHELL = /bin/sh
+
+## Gradle
+GW = ./gradlew
+GFLAGS ?=
+GW_CMD = $(GW) $(GFLAGS)
+
+reviews/check: ## Builds and checks the reviews-dgs
+	@cd reviews-dgs && \
+		$(GW_CMD) clean check
+
+shows/check: ## Builds and checks the shows-dgs
+	@cd shows-dgs && \
+		$(GW_CMD) clean check
+
+all: reviews/check shows/check  ## Cleans, checks/tests, publishes the plugin locally and runs the examples.
+
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This commit attempts to enable Dependabot and Github CI workflows.